### PR TITLE
Fix for consul when no Private IP is available

### DIFF
--- a/configuration/salt/state/consul/config/client/consul-client.service
+++ b/configuration/salt/state/consul/config/client/consul-client.service
@@ -7,7 +7,7 @@ After=network-online.target
 EnvironmentFile=-/etc/sysconfig/consul
 Environment=GOMAXPROCS=2
 Restart=on-failure
-ExecStart=/opt/consul/agent/consul agent $OPTIONS -config-dir=/etc/opt/consul.d  -bind={{GetPrivateIP}}
+ExecStart=/opt/consul/agent/consul agent $OPTIONS -config-dir=/etc/opt/consul.d -bind '{{ GetAllInterfaces | include "flags" "forwardable" | sort "private" | attr "address" }}'
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 

--- a/configuration/salt/state/consul/config/server/consul-server.service
+++ b/configuration/salt/state/consul/config/server/consul-server.service
@@ -7,7 +7,7 @@ After=network-online.target
 EnvironmentFile=-/etc/sysconfig/consul
 Environment=GOMAXPROCS=2
 Restart=on-failure
-ExecStart=/opt/consul/agent/consul agent $OPTIONS -config-dir=/etc/opt/consul.d -bind={{GetPrivateIP}}
+ExecStart=/opt/consul/agent/consul agent $OPTIONS -config-dir=/etc/opt/consul.d -bind '{{ GetAllInterfaces | include "flags" "forwardable" | sort "private" | attr "address" }}'
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGINT
 


### PR DESCRIPTION
On NeCTAR, instances are assigned only a public IP and are not assigned a private IP. However, Butler's consul service config defaults to using a private IP. As a result, Consul ends up attempting to bind to the first available private IP, which is a link-local IPv6 address, and therefore fails. To make Butler work in this scenario, Consul needs to be configured to prefer a private IP if available, but fallback to a public IP if not, while ignoring link-local and loopback addresses.